### PR TITLE
Add LUX to airports list

### DIFF
--- a/airport_iata.json
+++ b/airport_iata.json
@@ -195,6 +195,10 @@
     "value":"SEN"
  },
  {
+     "text":"Luxembourg",
+     "value":"LUX"
+ },
+ {
     "text":"Madrid",
     "value":"MAD"
  },


### PR DESCRIPTION
Adding the LUX airport to the list of airport codes. RyanAir has regular flights to and from LUX airport.